### PR TITLE
ubuntu-20.04 - php7.4で失敗する問題を修正

### DIFF
--- a/lib/apt-install-php-ubuntu.sh
+++ b/lib/apt-install-php-ubuntu.sh
@@ -47,7 +47,10 @@ fi
 
 if [[ $release = 'focal' && `echo "$version < 8.0" | bc` == 1 ]]
 then
-    sudo apt install php${version}-common=7.4.3-4ubuntu2.16 -y --allow-downgrades
+    if [[ "${version}" = "7.4"]]
+    then
+        sudo apt install php${version}-common=7.4.3-4ubuntu2.16 -y --allow-downgrades
+    fi
     sudo apt-fast install -y \
          php${version}-json \
          php${version}-xmlrpc

--- a/lib/apt-install-php-ubuntu.sh
+++ b/lib/apt-install-php-ubuntu.sh
@@ -47,6 +47,7 @@ fi
 
 if [[ $release = 'focal' && `echo "$version < 8.0" | bc` == 1 ]]
 then
+    sudo apt install php${version}-common=7.4.3-4ubuntu2.16 -y --allow-downgrades
     sudo apt-fast install -y \
          php${version}-json \
          php${version}-xmlrpc

--- a/lib/apt-install-php-ubuntu.sh
+++ b/lib/apt-install-php-ubuntu.sh
@@ -47,8 +47,7 @@ fi
 
 if [[ $release = 'focal' && `echo "$version < 8.0" | bc` == 1 ]]
 then
-    if [[ "${version}" = "7.4"]]
-    then
+    if [[ "${version}" = "7.4" ]]; then
         sudo apt install php${version}-common=7.4.3-4ubuntu2.16 -y --allow-downgrades
     fi
     sudo apt-fast install -y \


### PR DESCRIPTION
ubuntu-20.04 - php7.4の組み合わせで失敗していました。
php74-xmlrpcのインストールに失敗していたようで、php-commonをダウングレードしています。

※actionsは通るようになりました。
https://github.com/chihiro-adachi/setup-php/actions/runs/3934729818

```
The following packages have unmet dependencies:
 php7.4-xmlrpc : Depends: php7.4-common (= 7.4.3-4ubuntu2.16) but 1:7.4.33-2+ubuntu20.04.1+deb.sury.org+1 is to be installed
E: Unable to correct problems, you have held broken packages.
```
